### PR TITLE
Setup from the dataset-related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- Setup dataset-related classes (#5)
 - Setup sgx-related classes. (#4)
 - Setup docker-related classes. (#2, #3)
 - Setup `WorkerConfigurationService`. (#1, #3)

--- a/src/main/java/com/iexec/standalone/dataset/DatasetService.java
+++ b/src/main/java/com/iexec/standalone/dataset/DatasetService.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020-2023 IEXEC BLOCKCHAIN TECH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iexec.standalone.dataset;
+
+import com.iexec.common.replicate.ReplicateStatusCause;
+import com.iexec.common.utils.FileHashUtils;
+import com.iexec.common.utils.FileHelper;
+import com.iexec.common.utils.IexecFileHelper;
+import com.iexec.commons.poco.task.TaskDescription;
+import com.iexec.commons.poco.utils.MultiAddressHelper;
+import com.iexec.standalone.config.WorkerConfigurationService;
+import com.iexec.standalone.utils.WorkflowException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+
+
+@Slf4j
+@Service
+public class DatasetService {
+
+    private final WorkerConfigurationService workerConfigurationService;
+
+    public DatasetService(WorkerConfigurationService workerConfigurationService) {
+        this.workerConfigurationService = workerConfigurationService;
+    }
+
+    /**
+     * Download dataset file for the given standard task and save
+     * it in {@link IexecFileHelper#SLASH_IEXEC_IN}.
+     * 
+     * @param taskDescription Task description containing dataset related parameters
+     * @return downloaded dataset file path
+     * @throws WorkflowException if download fails or bad checksum.
+     */
+    public String downloadStandardDataset(@Nonnull TaskDescription taskDescription)
+            throws WorkflowException {
+        String chainTaskId = taskDescription.getChainTaskId();
+        String uri = taskDescription.getDatasetUri();
+        String filename = taskDescription.getDatasetAddress();
+        String parentDirectoryPath = workerConfigurationService.getTaskInputDir(chainTaskId);
+        String datasetLocalFilePath = "";
+        if (MultiAddressHelper.isMultiAddress(uri)) {
+            for (String ipfsGateway : MultiAddressHelper.IPFS_GATEWAYS) {
+                log.debug("Try to download dataset from {}", ipfsGateway);
+                datasetLocalFilePath =
+                        downloadFile(chainTaskId, ipfsGateway + uri, parentDirectoryPath, filename);
+                if (!datasetLocalFilePath.isEmpty()) {
+                    break;
+                }
+            }
+        } else {
+            datasetLocalFilePath =
+                    downloadFile(chainTaskId, uri, parentDirectoryPath, filename);
+        }
+        if (datasetLocalFilePath.isEmpty()) {
+            throw new WorkflowException(ReplicateStatusCause.DATASET_FILE_DOWNLOAD_FAILED);
+        }
+        String expectedSha256 = taskDescription.getDatasetChecksum();
+        if (StringUtils.isEmpty(expectedSha256)) {
+            log.warn("INSECURE! Cannot check empty on-chain dataset checksum " +
+                    "[chainTaskId:{}]", chainTaskId);
+            return datasetLocalFilePath;
+        }
+        String actualSha256 = FileHashUtils.sha256(new File(datasetLocalFilePath));
+        if (!expectedSha256.equals(actualSha256)) {
+            log.error("Dataset checksum mismatch [chainTaskId:{}, " +
+                    "expected:{}, actual:{}]", chainTaskId, expectedSha256,
+                    actualSha256);
+            throw new WorkflowException(ReplicateStatusCause.DATASET_FILE_BAD_CHECKSUM);
+        }
+        return datasetLocalFilePath;
+    }
+
+    /**
+     * Download input files for the given standard task and save them
+     * in the input folder.
+     * 
+     * @param chainTaskId Task ID used to create input files download folder
+     * @param uriList List of input files to download
+     * @throws WorkflowException if download fails.
+     */
+    public void downloadStandardInputFiles(String chainTaskId, @Nonnull List<String> uriList)
+            throws WorkflowException {
+        for (String uri: uriList) {
+            String filename = !StringUtils.isEmpty(uri)
+                    ? Paths.get(uri).getFileName().toString()
+                    : "";
+            String parenDirectoryPath = workerConfigurationService.getTaskInputDir(chainTaskId);
+            if (downloadFile(chainTaskId, uri, parenDirectoryPath, filename).isEmpty()) {
+                throw new WorkflowException(ReplicateStatusCause.INPUT_FILES_DOWNLOAD_FAILED);
+            }
+        }
+    }
+
+    /**
+     * Download a file from a URI in the provided parent
+     * directory and save it with the provided filename.
+     * 
+     * @param chainTaskId Task ID, for logging purpose
+     * @param uri URI of  single file to download
+     * @param parentDirectoryPath Destination folder on worker host
+     * @param filename Name of downloaded file in destination folder
+     * @return absolute path of the saved file on worker host
+     */
+    String downloadFile(String chainTaskId, String uri,
+                        String parentDirectoryPath, String filename) {
+        if (StringUtils.isEmpty(chainTaskId) ||
+                StringUtils.isEmpty(uri) ||
+                StringUtils.isEmpty(parentDirectoryPath) ||
+                StringUtils.isEmpty(filename)) {
+            log.error("Failed to download, args shouldn't be empty " +
+                    "[chainTaskId:{}, datasetUri:{}, parentDir:{}, filename:{}]",
+                    chainTaskId, uri, parentDirectoryPath, filename);
+            return StringUtils.EMPTY;
+        }
+        return FileHelper.downloadFile(uri, parentDirectoryPath, filename);
+    }
+}

--- a/src/main/java/com/iexec/standalone/utils/WorkflowException.java
+++ b/src/main/java/com/iexec/standalone/utils/WorkflowException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 IEXEC BLOCKCHAIN TECH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iexec.standalone.utils;
+
+import com.iexec.common.replicate.ReplicateStatusCause;
+import lombok.Getter;
+
+@Getter
+public class WorkflowException extends Exception {
+
+    private final ReplicateStatusCause replicateStatusCause;
+
+    public WorkflowException(ReplicateStatusCause cause) {
+        this(cause, cause.name());
+    }
+
+    public WorkflowException(ReplicateStatusCause cause, String message) {
+        super(message);
+        this.replicateStatusCause = cause;
+    }
+
+}

--- a/src/test/java/com/iexec/standalone/dataset/DatasetServiceTests.java
+++ b/src/test/java/com/iexec/standalone/dataset/DatasetServiceTests.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2020-2023 IEXEC BLOCKCHAIN TECH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iexec.standalone.dataset;
+
+import com.iexec.common.replicate.ReplicateStatusCause;
+import com.iexec.commons.poco.task.TaskDescription;
+import com.iexec.standalone.config.WorkerConfigurationService;
+import com.iexec.standalone.utils.WorkflowException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(OutputCaptureExtension.class)
+class DatasetServiceTests {
+
+    private static final String CHAIN_TASK_ID = "chainTaskId";
+    private static final String DATASET_ADDRESS = "0x7293635a7891ceb3368b87e4a23b6ea41b78b962";
+    private static final String DATASET_RESOURCE_NAME = "iExec-RLC-RLC-icon.png";
+    private static final String HTTP_URI = "https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/512/" + DATASET_RESOURCE_NAME;
+    private static final String IPFS_URI = "/ipfs/QmUbh7ugQ9WVprTVYjzrCS4d9cCy73zUz4MMchsrqzzu1w";
+    private static final String IEXEC_IPFS_DOWNLOAD = "Try to download dataset from https://ipfs-gateway.v8-bellecour.iex.ec";
+    private static final String IO_IPFS_DOWNLOAD = "Try to download dataset from https://gateway.ipfs.io";
+    private static final String PINATA_IPFS_DOWNLOAD = "Try to download dataset from https://gateway.pinata.cloud";
+    private static final String CHECKSUM = "0x4d8401fd4484f07c202c0a2b9ce6907eabd69efae0cec3956f1a56a6b19a9daa";
+
+    @TempDir
+    public File temporaryFolder;
+
+    @Spy
+    @InjectMocks
+    private DatasetService dataService;
+
+    @Mock
+    private WorkerConfigurationService workerConfigurationService;
+
+    private String iexecIn;
+
+    private TaskDescription.TaskDescriptionBuilder getTaskDescriptionBuilder() {
+        return TaskDescription.builder()
+                .chainTaskId(CHAIN_TASK_ID)
+                .datasetUri(HTTP_URI)
+                .datasetChecksum(CHECKSUM)
+                .datasetAddress(DATASET_ADDRESS)
+                .isTeeTask(false);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.openMocks(this);
+        iexecIn = temporaryFolder.getAbsolutePath();
+        when(workerConfigurationService.getTaskInputDir(CHAIN_TASK_ID))
+                .thenReturn(iexecIn);
+    }
+
+    @Test
+    void shouldDownloadStandardTaskDataset() throws Exception {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder().build();
+        String filepath = dataService.downloadStandardDataset(taskDescription);
+        assertThat(filepath).isEqualTo(iexecIn + "/" + DATASET_ADDRESS);
+    }
+
+    @Test
+    void shouldDownloadStandardDatasetFromIexecGateway(CapturedOutput output) throws WorkflowException {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetUri(IPFS_URI)
+                .build();
+        final URL resourceFile = this.getClass().getClassLoader().getResource(DATASET_RESOURCE_NAME);
+        assertThat(resourceFile).isNotNull();
+        when(dataService.downloadFile(anyString(), anyString(), anyString(), anyString())).thenReturn(resourceFile.getFile());
+        final String filepath = dataService.downloadStandardDataset(taskDescription);
+        assertThat(filepath).isNotEmpty();
+        assertThat(output)
+                .contains(IEXEC_IPFS_DOWNLOAD)
+                .doesNotContain(IO_IPFS_DOWNLOAD)
+                .doesNotContain(PINATA_IPFS_DOWNLOAD);
+    }
+
+    @Test
+    void shouldDownloadStandardDatasetFromIpfsGateway(CapturedOutput output) throws WorkflowException {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetUri(IPFS_URI)
+                .build();
+        final URL resourceFile = this.getClass().getClassLoader().getResource(DATASET_RESOURCE_NAME);
+        assertThat(resourceFile).isNotNull();
+        when(dataService.downloadFile(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("")
+                .thenReturn(resourceFile.getFile());
+        final String filepath = dataService.downloadStandardDataset(taskDescription);
+        assertThat(filepath).isNotEmpty();
+        assertThat(output)
+                .contains(IEXEC_IPFS_DOWNLOAD)
+                .contains(IO_IPFS_DOWNLOAD)
+                .doesNotContain(PINATA_IPFS_DOWNLOAD);
+    }
+
+    @Test
+    void shouldDownloadStandardDatasetFromPinataGateway(CapturedOutput output) throws WorkflowException {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetUri(IPFS_URI)
+                .build();
+        final URL resourceFile = this.getClass().getClassLoader().getResource(DATASET_RESOURCE_NAME);
+        assertThat(resourceFile).isNotNull();
+        when(dataService.downloadFile(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("")
+                .thenReturn("")
+                .thenReturn(resourceFile.getFile());
+        final String filepath = dataService.downloadStandardDataset(taskDescription);
+        assertThat(filepath).isNotEmpty();
+        assertThat(output)
+                .contains(IEXEC_IPFS_DOWNLOAD)
+                .contains(IO_IPFS_DOWNLOAD)
+                .contains(PINATA_IPFS_DOWNLOAD);
+    }
+
+    @Test
+    void shouldNotDownloadDatasetWhenFailureOnAllGateways(CapturedOutput output) throws WorkflowException {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetUri(IPFS_URI)
+                .build();
+        final URL resourceFile = this.getClass().getClassLoader().getResource(DATASET_RESOURCE_NAME);
+        assertThat(resourceFile).isNotNull();
+        when(dataService.downloadFile(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("");
+        assertThrows(
+                WorkflowException.class
+                , () -> dataService.downloadStandardDataset(taskDescription)
+        );
+        assertThat(output)
+                .contains(IEXEC_IPFS_DOWNLOAD)
+                .contains(IO_IPFS_DOWNLOAD)
+                .contains(PINATA_IPFS_DOWNLOAD);
+    }
+
+    @Test
+    void shouldNotDownloadDatasetSinceEmptyChainTaskId() {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .chainTaskId("")
+                .build();
+        WorkflowException e = assertThrows(
+                WorkflowException.class,
+                () -> dataService.downloadStandardDataset(taskDescription));
+        assertThat(e.getReplicateStatusCause())
+                .isEqualTo(ReplicateStatusCause.DATASET_FILE_DOWNLOAD_FAILED);
+    }
+
+    @Test
+    void shouldNotDownloadDatasetSinceEmptyUri() {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetUri("")
+                .build();
+        WorkflowException e = assertThrows(
+                WorkflowException.class,
+                () -> dataService.downloadStandardDataset(taskDescription));
+        assertThat(e.getReplicateStatusCause())
+                .isEqualTo(ReplicateStatusCause.DATASET_FILE_DOWNLOAD_FAILED);
+    }
+
+    @Test
+
+    void shouldNotDownloadDatasetSinceEmptyDatasetAddress() {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetAddress("")
+                .build();
+        WorkflowException e = assertThrows(
+                WorkflowException.class,
+                () -> dataService.downloadStandardDataset(taskDescription));
+        assertThat(e.getReplicateStatusCause())
+                .isEqualTo(ReplicateStatusCause.DATASET_FILE_DOWNLOAD_FAILED);
+    }
+
+    @Test
+    void shouldNotDownloadDatasetSinceEmptyParentDirectory() {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder().build();
+        when(workerConfigurationService.getTaskInputDir(CHAIN_TASK_ID)).thenReturn("");
+        WorkflowException e = assertThrows(
+                WorkflowException.class,
+                () -> dataService.downloadStandardDataset(taskDescription));
+        assertThat(e.getReplicateStatusCause())
+                .isEqualTo(ReplicateStatusCause.DATASET_FILE_DOWNLOAD_FAILED);
+    }
+
+    @Test
+    void shouldNotDownloadDatasetSinceBadChecksum() {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetChecksum("badChecksum")
+                .build();
+        WorkflowException e = assertThrows(
+                WorkflowException.class,
+                () -> dataService.downloadStandardDataset(taskDescription));
+        assertThat(e.getReplicateStatusCause())
+                .isEqualTo(ReplicateStatusCause.DATASET_FILE_BAD_CHECKSUM);
+    }
+
+    @Test
+    void shouldDownloadDatasetSinceEmptyOnchainChecksum() throws Exception {
+        final TaskDescription taskDescription = getTaskDescriptionBuilder()
+                .datasetChecksum("")
+                .build();
+        assertThat(dataService.downloadStandardDataset(taskDescription))
+                .isEqualTo(iexecIn + "/" + DATASET_ADDRESS);
+    }
+
+    @Test
+    void shouldDownloadInputFiles() throws Exception {
+        List<String> uris = List.of(HTTP_URI);
+        dataService.downloadStandardInputFiles(CHAIN_TASK_ID, uris);
+        File inputFile = new File(iexecIn, "iExec-RLC-RLC-icon.png");
+        assertThat(inputFile).exists();
+    }
+}


### PR DESCRIPTION
Repatriation of the [iexec-worker/src/main/java/com/iexec/worker/dataset](https://github.com/iExecBlockchainComputing/iexec-worker/tree/main/src/main/java/com/iexec/worker/dataset) package and the associated test class from the [main · iExecBlockchainComputing/iexec-worker](https://github.com/iExecBlockchainComputing/iexec-worker) project.